### PR TITLE
Adding python venv for local use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist/
 *.egg
 *.py[cod]
 __pycache__/
+.venv
 *.so
 *~
 # due to using tox and pytest

--- a/SOP_Programm/SOP_Gui.sh
+++ b/SOP_Programm/SOP_Gui.sh
@@ -1,2 +1,8 @@
-#!/bin/sh
-python3 SOPGUI.py
+#!/usr/bin/env bash
+if [ -f ".venv/bin/python" ]; then
+    echo "using virtual environment.."
+    .venv/bin/python SOPGUI.py
+else 
+    python3 SOPGUI.py
+fi
+

--- a/SOP_Programm/Setup_venv.sh
+++ b/SOP_Programm/Setup_venv.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# -> does not work with source'ing: #!/bin/sh
+#
+# setup python virtual environment
+python3 -m venv --system-site-packages .venv && source ./.venv/bin/activate
+pip install -r requirements.txt


### PR DESCRIPTION
This change allows to use the SOP_Gui inside a python virtual environment.
It prevents messing around with different library versions. (requirements.txt vs. local installed ones)

The change is intended for local use. If run inside the docker container, a venv is not necessary.

**Not working/missing :**  above changes for Windows